### PR TITLE
Prefer adding current entity filter as a query filter instead 

### DIFF
--- a/Model/Layer/CustomEntity/CollectionFilter.php
+++ b/Model/Layer/CustomEntity/CollectionFilter.php
@@ -19,6 +19,8 @@ use Magento\Framework\Registry;
 use Smile\CustomEntity\Api\Data\CustomEntityInterface;
 use Smile\CustomEntityProductLink\Helper\Product as ProductHelper;
 use Smile\ElasticsuiteCore\Helper\Mapping;
+use Smile\ElasticsuiteCore\Search\Request\Query\QueryFactory;
+use Smile\ElasticsuiteCore\Search\Request\QueryInterface;
 
 /**
  * Custom entity view layer collection filter model.
@@ -40,9 +42,9 @@ class CollectionFilter extends BaseCollectionFilter implements CollectionFilterI
     private $productHelper;
 
     /**
-     * @var Mapping
+     * @var \Smile\ElasticsuiteCore\Search\Request\Query\QueryFactory
      */
-    private $mappingHelper;
+    private $queryFactory;
 
     /**
      * CollectionFilter constructor.
@@ -58,12 +60,12 @@ class CollectionFilter extends BaseCollectionFilter implements CollectionFilterI
         \Magento\Catalog\Model\Config $catalogConfig,
         ProductHelper $productHelper,
         Registry $registry,
-        Mapping $mappingHelper
+        QueryFactory $queryFactory
     ) {
         parent::__construct($productVisibility, $catalogConfig);
         $this->productHelper = $productHelper;
         $this->registry = $registry;
-        $this->mappingHelper = $mappingHelper;
+        $this->queryFactory  = $queryFactory;
     }
 
     /**
@@ -79,10 +81,12 @@ class CollectionFilter extends BaseCollectionFilter implements CollectionFilterI
         parent::filter($collection, $category);
         $currentCustomEntity = $this->getCurrentCustomEntity();
         if (null !== $currentCustomEntity && $currentCustomEntity->getId() && $this->getAttributeCode()) {
-            $collection->addFieldToFilter(
-                $this->mappingHelper->getOptionTextFieldName($this->getAttributeCode()),
-                [$currentCustomEntity->getName()]
+            $query = $this->queryFactory->create(
+                QueryInterface::TYPE_TERM,
+                ['field' => $this->getAttributeCode(), 'value' => $currentCustomEntity->getId()]
             );
+
+            $collection->addQueryFilter($query);
         }
     }
 


### PR DESCRIPTION
of mimicing the appliance of a filter.

Why ? 

because when using just `addFieldToFilter` it's like filtering on a layered navigation filter. And since they are meant to be used as multiselect, the filter is applied to the collection (correct), to all other aggregations (correct), but not to the "currently applied filter" aggregation.

Also because layered navigation filters are applied as `post_filter` to allow proper drawing of the layered navigation mechanism (documentation is quite clear about this) : https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-post-filter.html
 
So in our case the query shew up like this (notice the non-filtered "brand" aggregation) : 

```
    "price.price": {
      "filter": {
        "terms": {
          "option_text_brand.untouched": [
            "Adidas"
          ],
          "boost": 1
        }
      },
      "aggregations": {
        "price.price": {
          "nested": {
            "path": "price"
          },
          "aggregations": {
            "price.price": {
              "filter": {
                "terms": {
                  "price.customer_group_id": [
                    0
                  ],
                  "boost": 1
                }
              },
              "aggregations": {
                "price.price": {
                  "histogram": {
                    "field": "price.price",
                    "interval": 1,
                    "min_doc_count": 1
                  }
                }
              }
            }
          }
        }
      }
    },
    "option_text_brand": {
      "terms": {
        "field": "option_text_brand.untouched",
        "size": 5,
        "order": {
          "_count": "desc"
        }
      }
    },
    "option_text_color": {
      "filter": {
        "terms": {
          "option_text_brand.untouched": [
            "Adidas"
          ],
          "boost": 1
        }
      },
      "aggregations": {
        "option_text_color": {
          "terms": {
            "field": "option_text_color.untouched",
            "size": 100000,
            "order": {
              "_count": "desc"
            }
          }
        }
      }
    },
    "option_text_material": {
      "filter": {
        "terms": {
          "option_text_brand.untouched": [
            "Adidas"
          ],
          "boost": 1
        }
      },
      "aggregations": {
        "option_text_material": {
          "terms": {
            "field": "option_text_material",
            "size": 10,
            "order": {
              "_count": "desc"
            }
          }
        }
      }
    },
```

And of course, in Front-office it was displayed this way (allowing to filter on other entities) : 

![Sélection_670](https://user-images.githubusercontent.com/15340849/56127641-e9d34a80-5f7d-11e9-92f4-c0aa067539e7.png)

Adding the filter as a raw Query Filter allow it to be applied on query time, and to ensure it's added to all aggregations of the current requests.

