### PR TITLE
fix: checking custom SQL select before injection

### DIFF
--- a/Model/ResourceModel/Search/CustomCollection.php
+++ b/Model/ResourceModel/Search/CustomCollection.php
@@ -59,7 +59,9 @@ class CustomCollection extends Collection
         $sql = parent::_getSearchEntityIdsSql($query, $searchOnlyInCurrentStore);
 
         $selects = $this->_getSmileCustomSql($query);
-        $sql = $sql->union($selects, \Magento\Framework\DB\Select::SQL_UNION_ALL);
+        if (!empty($selects)) { 
+            $sql = $sql->union($selects, \Magento\Framework\DB\Select::SQL_UNION_ALL);
+        }
 
         return $sql;
     }
@@ -86,6 +88,7 @@ class CustomCollection extends Collection
             $smileCustomEntityAttributeIds[] = $attribute->getId();
         }
 
+        $selects = [];
         if ($smileCustomEntityAttributeIds) {
             $selects[] = $this->getConnection()->select()->from(
                 ['cpe' => 'catalog_product_entity'],


### PR DESCRIPTION
Good afternoon,

Related to this issue #24, this pull requests check wether we need to inject Smile Custom Entity SQL with Magento one or not.

I am testing this issue on last version of Magento (2.4.1) and it solved my problem,

Sincerely yours,

Ilan Parmentier