### PR TITLE
Products list addto name block

### DIFF
--- a/view/frontend/layout/smile_custom_entity_entity_view_product_list.xml
+++ b/view/frontend/layout/smile_custom_entity_entity_view_product_list.xml
@@ -34,7 +34,7 @@
                 <block class="Magento\Framework\View\Element\RendererList" name="category.product.type.details.renderers" as="details.renderers">
                     <block class="Magento\Framework\View\Element\Template" name="category.product.type.details.renderers.default" as="default"/>
                 </block>
-                <block class="Magento\Catalog\Block\Product\ProductList\Item\Container" name="catalogsearch.product.addto" as="addto">
+                <block class="Magento\Catalog\Block\Product\ProductList\Item\Container" name="category.product.addto" as="addto">
                     <block class="Magento\Catalog\Block\Product\ProductList\Item\AddTo\Compare"
                            name="catalogsearch.product.addto.compare" as="compare"
                            template="Magento_Catalog::product/list/addto/compare.phtml"/>


### PR DESCRIPTION
I was trying to add wishlist button to the current list without success.

For now (in theme, Magento_Wishlist directory) :
Note **catalogsearch.product.addto**
```
<?xml version="1.0"?>
<!--
/**
 * Copyright © Magento, Inc. All rights reserved.
 * See COPYING.txt for license details.
 */
-->
<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
    <body>
        <referenceContainer name="content">
            <block class="Magento\Cookie\Block\RequireCookie" name="require-cookie" template="Magento_Cookie::require_cookie.phtml">
                <arguments>
                    <argument name="triggers" xsi:type="array">
                        <item name="addToWishlistLink" xsi:type="string">.action.towishlist</item>
                    </argument>
                </arguments>
            </block>
            <referenceBlock name="catalogsearch.product.addto">
                <block class="Magento\Wishlist\Block\Catalog\Product\ProductList\Item\AddTo\Wishlist"
                       name="category.product.addto.wishlist" as="wishlist" before="compare"
                       template="Magento_Wishlist::catalog/product/list/addto/wishlist.phtml"/>
            </referenceBlock>
            <referenceContainer name="category.product.list.additional">
                <block class="Magento\Wishlist\Block\AddToWishlist"
                    name="category.product.list.additional.wishlist_addto"
                    template="Magento_Wishlist::addto.phtml"/>
            </referenceContainer>
        </referenceContainer>
    </body>
</page>
```