### PR TITLE
Fix return type on the cart price rule creation BO page

### DIFF
--- a/Plugin/Model/ResourceModel/Eav/Attribute.php
+++ b/Plugin/Model/ResourceModel/Eav/Attribute.php
@@ -17,6 +17,6 @@ class Attribute
             $result = $subject->getIsVisible();
         }
 
-        return $result;
+        return (bool) $result;
     }
 }


### PR DESCRIPTION
Type Error occurred when creating object: Magento\SalesRule\Model\Rule\Condition\Product\Interceptor, Smile\CustomEntityProductLink\Plugin\Model\ResourceModel\Eav\Attribute::afterIsAllowedForRuleCondition(): Return value must be of type bool, string returned